### PR TITLE
[update]Fix rendering table for table refactoring.

### DIFF
--- a/src/DeltaInsertOp.ts
+++ b/src/DeltaInsertOp.ts
@@ -208,6 +208,10 @@ class DeltaInsertOp {
     );
   }
 
+  isListNestedInTable() {
+    return !!this.attributes?.list?.cell;
+  }
+
   isOrderedList() {
     return (
       !!this.attributes.list && this.attributes.list!.list === ListType.Ordered

--- a/src/QuillDeltaToHtmlConverter.ts
+++ b/src/QuillDeltaToHtmlConverter.ts
@@ -245,10 +245,10 @@ class QuillDeltaToHtmlConverter {
     var firstItem = list.items[0];
     let attrsOfList: ITagKeyValue[] = !!list.headOp
       ? [
-          { key: 'data-row', value: list.headOp.attributes!.row },
-          { key: 'data-cell', value: list.headOp.attributes!.cell },
-          { key: 'data-rowspan', value: list.headOp.attributes!.rowspan },
-          { key: 'data-colspan', value: list.headOp.attributes!.colspan },
+          { key: 'data-row', value: list.headOp.attributes.list?.row },
+          { key: 'data-cell', value: list.headOp.attributes.list?.cell },
+          { key: 'data-rowspan', value: list.headOp.attributes.list?.rowspan },
+          { key: 'data-colspan', value: list.headOp.attributes.list?.colspan },
         ]
       : [];
 
@@ -353,10 +353,11 @@ class QuillDeltaToHtmlConverter {
       ? this.options.customTableCellAttrs(cell)
       : [];
 
+    const cellAttributes = cell.attrs?.['table-cell-line'] || cell.attrs?.list;
     const attributes: ITagKeyValue[] = [
-      { key: 'data-row', value: cell.attrs!.row },
-      { key: 'rowspan', value: cell.attrs!.rowspan },
-      { key: 'colspan', value: cell.attrs!.colspan },
+      { key: 'data-row', value: cellAttributes?.row },
+      { key: 'rowspan', value: cellAttributes?.rowspan },
+      { key: 'colspan', value: cellAttributes?.colspan },
     ];
 
     customAttributes.forEach((item) => {

--- a/src/grouper/TableGrouper.ts
+++ b/src/grouper/TableGrouper.ts
@@ -41,23 +41,19 @@ export class TableGrouper {
           (g instanceof ListGroup &&
             gPrev instanceof BlockGroup &&
             g.headOp &&
-            g.headOp!.attributes &&
-            g.headOp!.attributes!.cell &&
+            g.headOp.isListNestedInTable() &&
             gPrev.op.isTableCellLine()) ||
           (g instanceof BlockGroup &&
             gPrev instanceof ListGroup &&
             g.op.isTableCellLine() &&
             gPrev.headOp &&
-            gPrev.headOp!.attributes &&
-            gPrev.headOp!.attributes!.cell) ||
+            gPrev.headOp.isListNestedInTable()) ||
           (g instanceof ListGroup &&
             gPrev instanceof ListGroup &&
             !!g.headOp &&
-            g.headOp!.attributes &&
             !!gPrev.headOp &&
-            gPrev.headOp!.attributes &&
-            g.headOp!.attributes!.cell &&
-            gPrev.headOp!.attributes!.cell) ||
+            g.headOp.isListNestedInTable() &&
+            gPrev.headOp.isListNestedInTable()) ||
           (g instanceof BlotBlock &&
             gPrev instanceof BlockGroup &&
             g.op.isEmptyTableCell() &&
@@ -74,13 +70,11 @@ export class TableGrouper {
             gPrev instanceof ListGroup &&
             g.op.isEmptyTableCell() &&
             gPrev.headOp &&
-            gPrev.headOp!.attributes &&
-            gPrev.headOp!.attributes!.cell) ||
+            gPrev.headOp.isListNestedInTable()) ||
           (g instanceof ListGroup &&
             gPrev instanceof BlotBlock &&
-            g.headOp &&
-            g.headOp!.attributes &&
-            g.headOp!.attributes!.cell &&
+            !!g.headOp &&
+            g.headOp.isListNestedInTable() &&
             gPrev.op.isEmptyTableCell())
         );
       }
@@ -101,7 +95,7 @@ export class TableGrouper {
                         item.op.attributes
                       ),
                     ],
-                    item.op.attributes.row
+                    item.op.attributes['table-cell-line']?.row
                   ),
                 ],
                 tableColGroup ||
@@ -123,7 +117,7 @@ export class TableGrouper {
                 [
                   new TableRow(
                     [new TableCell([item], item.headOp.attributes)],
-                    item.headOp.attributes.row
+                    item.headOp.attributes.list?.row
                   ),
                 ],
                 tableColGroup ||
@@ -169,8 +163,12 @@ export class TableGrouper {
         return (
           g instanceof TableCell &&
           gPrev instanceof TableCell &&
-          (g.attrs ? g.attrs.row : undefined) ===
-            (gPrev.attrs ? gPrev.attrs.row : undefined)
+          (g.attrs?.['table-cell-line']?.row ||
+            g.attrs?.list?.row ||
+            undefined) ===
+            (gPrev.attrs?.['table-cell-line']?.row ||
+              gPrev.attrs?.list?.row ||
+              undefined)
         );
       }
     );
@@ -180,14 +178,16 @@ export class TableGrouper {
       if (Array.isArray(item)) {
         const firstCell = item[0];
         if (firstCell) {
-          row = firstCell.attrs ? firstCell.attrs.row : undefined;
+          row =
+            firstCell.attrs?.['table-cell-line']?.row ||
+            firstCell.attrs?.list?.row ||
+            undefined;
         }
       } else {
-        if (item.attrs) {
-          row = item.attrs.row;
-        } else {
-          row = undefined;
-        }
+        row =
+          item.attrs?.['table-cell-line']?.row ||
+          item.attrs?.list?.row ||
+          undefined;
       }
 
       return new TableRow(

--- a/src/grouper/group-types.ts
+++ b/src/grouper/group-types.ts
@@ -68,7 +68,7 @@ class ListGroup {
   }
 
   private setHeadOpIfThisListIsNestedWithTable(item: ListItem) {
-    if (item && item.item.op.attributes && item.item.op.attributes.cell) {
+    if (item && item.item.op.attributes && item.item.op.attributes.list?.cell) {
       this.headOp = item.item.op;
     }
   }

--- a/test/QuillDeltaToHtmlConverter.test.ts
+++ b/test/QuillDeltaToHtmlConverter.test.ts
@@ -756,6 +756,258 @@ describe('QuillDeltaToHtmlConverter', function () {
       );
     });
 
+    // test cases for refactored cu-table
+    it('should render empty cu-table', () => {
+      let ops = [
+        {
+          attributes: {
+            'table-col': { width: '150' },
+          },
+          insert: '\n\n\n',
+        },
+        {
+          attributes: {
+            'table-cell-line': {
+              rowspan: '1',
+              colspan: '1',
+              row: 'row-dvagmt',
+              cell: 'cell-383p7o',
+            },
+          },
+          insert: '\n',
+        },
+        {
+          attributes: {
+            'table-cell-line': {
+              rowspan: '1',
+              colspan: '1',
+              row: 'row-dvagmt',
+              cell: 'cell-kdrmch',
+            },
+          },
+          insert: '\n',
+        },
+        {
+          attributes: {
+            'table-cell-line': {
+              rowspan: '1',
+              colspan: '1',
+              row: 'row-dvagmt',
+              cell: 'cell-ljjq9j',
+            },
+          },
+          insert: '\n',
+        },
+        {
+          attributes: {
+            'table-cell-line': {
+              rowspan: '1',
+              colspan: '1',
+              row: 'row-929dk8',
+              cell: 'cell-lj7h6y',
+            },
+          },
+          insert: '\n',
+        },
+        {
+          attributes: {
+            'table-cell-line': {
+              rowspan: '1',
+              colspan: '1',
+              row: 'row-929dk8',
+              cell: 'cell-l0enbj',
+            },
+          },
+          insert: '\n',
+        },
+        {
+          attributes: {
+            'table-cell-line': {
+              rowspan: '1',
+              colspan: '1',
+              row: 'row-929dk8',
+              cell: 'cell-xa4lb9',
+            },
+          },
+          insert: '\n',
+        },
+        {
+          attributes: {
+            'table-cell-line': {
+              rowspan: '1',
+              colspan: '1',
+              row: 'row-j95olh',
+              cell: 'cell-2w5wjp',
+            },
+          },
+          insert: '\n',
+        },
+        {
+          attributes: {
+            'table-cell-line': {
+              rowspan: '1',
+              colspan: '1',
+              row: 'row-j95olh',
+              cell: 'cell-o7q92h',
+            },
+          },
+          insert: '\n',
+        },
+        {
+          attributes: {
+            'table-cell-line': {
+              rowspan: '1',
+              colspan: '1',
+              row: 'row-j95olh',
+              cell: 'cell-4nujo2',
+            },
+          },
+          insert: '\n',
+        },
+      ];
+
+      let qdc = new QuillDeltaToHtmlConverter(ops);
+      assert.equal(
+        qdc.convert(),
+        [
+          `<div class="clickup-table-view">`,
+          `<table class="clickup-table" style="width: 450px">`,
+          `<colgroup>`,
+          `<col width="150"><col width="150"><col width="150">`,
+          `</colgroup>`,
+          `<tbody>`,
+          `<tr data-row="row-dvagmt">`,
+          `<td data-row="row-dvagmt" rowspan="1" colspan="1"><p class="qlbt-cell-line" data-row="row-dvagmt" data-cell="cell-383p7o" data-rowspan="1" data-colspan="1"><br/></p></td>`,
+          `<td data-row="row-dvagmt" rowspan="1" colspan="1"><p class="qlbt-cell-line" data-row="row-dvagmt" data-cell="cell-kdrmch" data-rowspan="1" data-colspan="1"><br/></p></td>`,
+          `<td data-row="row-dvagmt" rowspan="1" colspan="1"><p class="qlbt-cell-line" data-row="row-dvagmt" data-cell="cell-ljjq9j" data-rowspan="1" data-colspan="1"><br/></p></td>`,
+          '</tr>',
+          `<tr data-row="row-929dk8">`,
+          `<td data-row="row-929dk8" rowspan="1" colspan="1"><p class="qlbt-cell-line" data-row="row-929dk8" data-cell="cell-lj7h6y" data-rowspan="1" data-colspan="1"><br/></p></td>`,
+          `<td data-row="row-929dk8" rowspan="1" colspan="1"><p class="qlbt-cell-line" data-row="row-929dk8" data-cell="cell-l0enbj" data-rowspan="1" data-colspan="1"><br/></p></td>`,
+          `<td data-row="row-929dk8" rowspan="1" colspan="1"><p class="qlbt-cell-line" data-row="row-929dk8" data-cell="cell-xa4lb9" data-rowspan="1" data-colspan="1"><br/></p></td>`,
+          '</tr>',
+          `<tr data-row="row-j95olh">`,
+          `<td data-row="row-j95olh" rowspan="1" colspan="1"><p class="qlbt-cell-line" data-row="row-j95olh" data-cell="cell-2w5wjp" data-rowspan="1" data-colspan="1"><br/></p></td>`,
+          `<td data-row="row-j95olh" rowspan="1" colspan="1"><p class="qlbt-cell-line" data-row="row-j95olh" data-cell="cell-o7q92h" data-rowspan="1" data-colspan="1"><br/></p></td>`,
+          `<td data-row="row-j95olh" rowspan="1" colspan="1"><p class="qlbt-cell-line" data-row="row-j95olh" data-cell="cell-4nujo2" data-rowspan="1" data-colspan="1"><br/></p></td>`,
+          '</tr>',
+          `</tbody>`,
+          `</table>`,
+          `</div>`,
+        ].join('')
+      );
+    });
+
+    it('should render table with list', () => {
+      let ops = [
+        {
+          attributes: {
+            'table-col': { width: '150' },
+          },
+          insert: '\n\n',
+        },
+        {
+          attributes: {
+            'table-cell-line': {
+              rowspan: '1',
+              colspan: '1',
+              row: 'row-dvagmt',
+              cell: 'cell-383p7o',
+            },
+          },
+          insert: '\n',
+        },
+        {
+          attributes: {
+            list: {
+              rowspan: '1',
+              colspan: '1',
+              row: 'row-dvagmt',
+              cell: 'cell-383p7o',
+              list: 'bullet',
+            },
+          },
+          insert: '\n',
+        },
+        {
+          attributes: {
+            'table-cell-line': {
+              rowspan: '1',
+              colspan: '1',
+              row: 'row-dvagmt',
+              cell: 'cell-kdrmch',
+            },
+          },
+          insert: '\n',
+        },
+        {
+          attributes: {
+            'table-cell-line': {
+              rowspan: '1',
+              colspan: '1',
+              row: 'row-929dk8',
+              cell: 'cell-lj7h6y',
+            },
+          },
+          insert: '\n',
+        },
+        {
+          attributes: {
+            'table-cell-line': {
+              rowspan: '1',
+              colspan: '1',
+              row: 'row-929dk8',
+              cell: 'cell-l0enbj',
+            },
+          },
+          insert: '\n',
+        },
+        {
+          attributes: {
+            list: {
+              rowspan: '1',
+              colspan: '1',
+              row: 'row-929dk8',
+              cell: 'cell-l0enbj',
+              list: 'ordered',
+            },
+          },
+          insert: '\n',
+        },
+      ];
+
+      let qdc = new QuillDeltaToHtmlConverter(ops);
+      assert.equal(
+        qdc.convert(),
+        [
+          `<div class="clickup-table-view">`,
+          `<table class="clickup-table" style="width: 300px">`,
+          `<colgroup>`,
+          `<col width="150"><col width="150">`,
+          `</colgroup>`,
+          `<tbody>`,
+          `<tr data-row="row-dvagmt">`,
+          `<td data-row="row-dvagmt" rowspan="1" colspan="1">`,
+          `<p class="qlbt-cell-line" data-row="row-dvagmt" data-cell="cell-383p7o" data-rowspan="1" data-colspan="1"><br/></p>`,
+          `<ul data-row="row-dvagmt" data-cell="cell-383p7o" data-rowspan="1" data-colspan="1"><li><br/></li></ul>`,
+          `</td>`,
+          `<td data-row="row-dvagmt" rowspan="1" colspan="1"><p class="qlbt-cell-line" data-row="row-dvagmt" data-cell="cell-kdrmch" data-rowspan="1" data-colspan="1"><br/></p></td>`,
+          '</tr>',
+          `<tr data-row="row-929dk8">`,
+          `<td data-row="row-929dk8" rowspan="1" colspan="1"><p class="qlbt-cell-line" data-row="row-929dk8" data-cell="cell-lj7h6y" data-rowspan="1" data-colspan="1"><br/></p></td>`,
+          `<td data-row="row-929dk8" rowspan="1" colspan="1">`,
+          `<p class="qlbt-cell-line" data-row="row-929dk8" data-cell="cell-l0enbj" data-rowspan="1" data-colspan="1"><br/></p>`,
+          `<ol data-row="row-929dk8" data-cell="cell-l0enbj" data-rowspan="1" data-colspan="1"><li><br/></li></ol>`,
+          `</td>`,
+          '</tr>',
+          `</tbody>`,
+          `</table>`,
+          `</div>`,
+        ].join('')
+      );
+    });
+
+    // test cases for columns
     it('should render columns with list', () => {
       let ops = [
         {

--- a/test/grouper/TableGrouper.test.ts
+++ b/test/grouper/TableGrouper.test.ts
@@ -11,7 +11,11 @@ import {
   TableRow,
   TableCell,
   TableCellLine,
+  ListGroup,
+  ListItem,
 } from '../../src/grouper/group-types';
+import { ListType } from '../../src/value-types';
+import { ListNester } from '../../src/grouper/ListNester';
 
 describe('TableGrouper', function () {
   describe('empty table', function () {
@@ -311,6 +315,282 @@ describe('TableGrouper', function () {
             ),
           ],
           new TableColGroup([new TableCol(<BlockGroup>groups[0])])
+        ),
+      ];
+
+      assert.deepEqual(act, exp);
+    });
+  });
+
+  /**
+   * test cases after refactor quill table.
+   * Refactoring removed unnecessary attributes from delta: row, cell, colspan, rowspan.
+   */
+  describe('empty table', function () {
+    var ops = [
+      new DeltaInsertOp('\n', { 'table-col': { width: '150' } }),
+      new DeltaInsertOp('\n', { 'table-col': { width: '150' } }),
+      new DeltaInsertOp('\n', { 'table-col': { width: '150' } }),
+      new DeltaInsertOp('\n', {
+        'table-cell-line': {
+          cell: 'cell-1',
+          row: 'row-1',
+          rowspan: '1',
+          colspan: '1',
+        },
+      }),
+      new DeltaInsertOp('\n', {
+        'table-cell-line': {
+          cell: 'cell-2',
+          row: 'row-1',
+          rowspan: '1',
+          colspan: '1',
+        },
+      }),
+      new DeltaInsertOp('\n', {
+        'table-cell-line': {
+          cell: 'cell-3',
+          row: 'row-1',
+          rowspan: '1',
+          colspan: '1',
+        },
+      }),
+      new DeltaInsertOp('\n', {
+        'table-cell-line': {
+          cell: 'cell-4',
+          row: 'row-2',
+          rowspan: '1',
+          colspan: '1',
+        },
+      }),
+      new DeltaInsertOp('\n', {
+        'table-cell-line': {
+          cell: 'cell-5',
+          row: 'row-2',
+          rowspan: '1',
+          colspan: '1',
+        },
+      }),
+      new DeltaInsertOp('\n', {
+        'table-cell-line': {
+          cell: 'cell-6',
+          row: 'row-2',
+          rowspan: '1',
+          colspan: '1',
+        },
+      }),
+      new DeltaInsertOp('\n', {
+        'table-cell-line': {
+          cell: 'cell-7',
+          row: 'row-3',
+          rowspan: '1',
+          colspan: '1',
+        },
+      }),
+      new DeltaInsertOp('\n', {
+        'table-cell-line': {
+          cell: 'cell-8',
+          row: 'row-3',
+          rowspan: '1',
+          colspan: '1',
+        },
+      }),
+      new DeltaInsertOp('\n', {
+        'table-cell-line': {
+          cell: 'cell-9',
+          row: 'row-3',
+          rowspan: '1',
+          colspan: '1',
+        },
+      }),
+    ];
+
+    it('should get 3x3 table', function () {
+      var groupsAct = Grouper.pairOpsWithTheirBlock(ops);
+      var groupsExp = Grouper.pairOpsWithTheirBlock(ops);
+      var tableGrouper = new TableGrouper();
+      var act = tableGrouper.group(groupsAct);
+      var exp = [
+        new TableGroup(
+          [
+            new TableRow(
+              [
+                new TableCell(
+                  [new TableCellLine(<BlockGroup>groupsExp[3])],
+                  ops[3].attributes
+                ),
+                new TableCell(
+                  [new TableCellLine(<BlockGroup>groupsExp[4])],
+                  ops[4].attributes
+                ),
+                new TableCell(
+                  [new TableCellLine(<BlockGroup>groupsExp[5])],
+                  ops[5].attributes
+                ),
+              ],
+              ops[3].attributes['table-cell-line']?.row
+            ),
+            new TableRow(
+              [
+                new TableCell(
+                  [new TableCellLine(<BlockGroup>groupsExp[6])],
+                  ops[6].attributes
+                ),
+                new TableCell(
+                  [new TableCellLine(<BlockGroup>groupsExp[7])],
+                  ops[7].attributes
+                ),
+                new TableCell(
+                  [new TableCellLine(<BlockGroup>groupsExp[8])],
+                  ops[8].attributes
+                ),
+              ],
+              ops[6].attributes['table-cell-line']?.row
+            ),
+            new TableRow(
+              [
+                new TableCell(
+                  [new TableCellLine(<BlockGroup>groupsExp[9])],
+                  ops[9].attributes
+                ),
+                new TableCell(
+                  [new TableCellLine(<BlockGroup>groupsExp[10])],
+                  ops[10].attributes
+                ),
+                new TableCell(
+                  [new TableCellLine(<BlockGroup>groupsExp[11])],
+                  ops[11].attributes
+                ),
+              ],
+              ops[9].attributes['table-cell-line']?.row
+            ),
+          ],
+          new TableColGroup([
+            new TableCol(<BlockGroup>groupsExp[0]),
+            new TableCol(<BlockGroup>groupsExp[1]),
+            new TableCol(<BlockGroup>groupsExp[2]),
+          ])
+        ),
+      ];
+
+      assert.deepEqual(act, exp);
+    });
+  });
+
+  describe('table with nested list', function () {
+    var ops = [
+      new DeltaInsertOp('\n', { 'table-col': { width: '150' } }),
+      new DeltaInsertOp('\n', { 'table-col': { width: '150' } }),
+      new DeltaInsertOp('\n', { 'table-col': { width: '150' } }),
+      new DeltaInsertOp('1-1'),
+      new DeltaInsertOp('\n', {
+        'table-cell-line': {
+          cell: 'cell-1',
+          row: 'row-1',
+          rowspan: '1',
+          colspan: '1',
+        },
+      }),
+      new DeltaInsertOp('list item 1-1'),
+      new DeltaInsertOp('\n', {
+        list: {
+          cell: 'cell-1',
+          row: 'row-1',
+          rowspan: '1',
+          colspan: '1',
+          list: ListType.Bullet,
+        },
+      }),
+      new DeltaInsertOp('1-2'),
+      new DeltaInsertOp('\n', {
+        'table-cell-line': {
+          cell: 'cell-2',
+          row: 'row-1',
+          rowspan: '1',
+          colspan: '1',
+        },
+      }),
+      new DeltaInsertOp('2-1'),
+      new DeltaInsertOp('\n', {
+        'table-cell-line': {
+          cell: 'cell-3',
+          row: 'row-2',
+          rowspan: '1',
+          colspan: '1',
+        },
+      }),
+      new DeltaInsertOp('2-2'),
+      new DeltaInsertOp('\n', {
+        'table-cell-line': {
+          cell: 'cell-4',
+          row: 'row-2',
+          rowspan: '1',
+          colspan: '1',
+        },
+      }),
+      new DeltaInsertOp('list item 2-2'),
+      new DeltaInsertOp('\n', {
+        list: {
+          cell: 'cell-4',
+          row: 'row-2',
+          rowspan: '1',
+          colspan: '1',
+          list: ListType.Ordered,
+        },
+      }),
+    ];
+
+    it('should get 2x2 table with lists', function () {
+      var groupsAct = Grouper.pairOpsWithTheirBlock(ops);
+      var groupsExp = Grouper.pairOpsWithTheirBlock(ops);
+
+      var listNester = new ListNester();
+      var listNested = listNester.nest(groupsAct);
+
+      var tableGrouper = new TableGrouper();
+      var act = tableGrouper.group(listNested);
+
+      var exp = [
+        new TableGroup(
+          [
+            new TableRow(
+              [
+                new TableCell(
+                  [
+                    new TableCellLine(<BlockGroup>groupsExp[3]),
+                    new ListGroup([new ListItem(<BlockGroup>groupsExp[4])]),
+                  ],
+                  ops[4].attributes
+                ),
+                new TableCell(
+                  [new TableCellLine(<BlockGroup>groupsExp[5])],
+                  ops[8].attributes
+                ),
+              ],
+              ops[4].attributes['table-cell-line']?.row
+            ),
+            new TableRow(
+              [
+                new TableCell(
+                  [new TableCellLine(<BlockGroup>groupsExp[6])],
+                  ops[10].attributes
+                ),
+                new TableCell(
+                  [
+                    new TableCellLine(<BlockGroup>groupsExp[7]),
+                    new ListGroup([new ListItem(<BlockGroup>groupsExp[8])]),
+                  ],
+                  ops[12].attributes
+                ),
+              ],
+              ops[10].attributes['table-cell-line']?.row
+            ),
+          ],
+          new TableColGroup([
+            new TableCol(<BlockGroup>groupsExp[0]),
+            new TableCol(<BlockGroup>groupsExp[1]),
+            new TableCol(<BlockGroup>groupsExp[2]),
+          ])
         ),
       ];
 


### PR DESCRIPTION
Added support for rendering refactored quill tables.
Added unit tests for table.

Refactoring Quill Table PR:
[https://github.com/time-loop/clickup_frontend/pull/26595](https://github.com/time-loop/clickup_frontend/pull/26595)

Caused issue:
<img width="577" alt="image" src="https://user-images.githubusercontent.com/68313886/211270510-2038909d-ec1a-4902-8676-d46b66010d78.png">
