### PR TITLE
[bugfix]Escape html code for code blocks nested with list.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@time-loop/quill-delta-to-html",
-  "version": "0.12.0-55",
+  "version": "0.12.0-56",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@time-loop/quill-delta-to-html",
-      "version": "0.12.0-55",
+      "version": "0.12.0-56",
       "license": "ISC",
       "dependencies": {
         "lodash-es": "^4.17.21"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@time-loop/quill-delta-to-html",
-  "version": "0.12.0-55",
+  "version": "0.12.0-56",
   "description": "Converts Quill's delta ops to HTML",
   "main": "./dist/commonjs/main.js",
   "types": "./dist/esm/main.d.ts",

--- a/src/QuillDeltaToHtmlConverter.ts
+++ b/src/QuillDeltaToHtmlConverter.ts
@@ -274,7 +274,11 @@ class QuillDeltaToHtmlConverter {
         : converter.getHtmlParts();
     var liElementsHtml;
     if (li.item instanceof BlockGroup) {
-      liElementsHtml = this._renderInlines(li.item.ops, true);
+      if (li.item.op.isCodeBlock()) {
+        liElementsHtml = this._renderBlock(li.item.op, li.item.ops);
+      } else {
+        liElementsHtml = this._renderInlines(li.item.ops, true);
+      }
     } else if (li.item instanceof BlotBlock) {
       liElementsHtml = this._renderCustom(li.item.op, null);
     } else if (li.item instanceof EmptyBlock) {

--- a/src/QuillDeltaToHtmlConverter.ts
+++ b/src/QuillDeltaToHtmlConverter.ts
@@ -275,7 +275,9 @@ class QuillDeltaToHtmlConverter {
     var liElementsHtml;
     if (li.item instanceof BlockGroup) {
       if (li.item.op.isCodeBlock()) {
-        liElementsHtml = this._renderBlock(li.item.op, li.item.ops);
+        liElementsHtml = encodeHtml(
+          li.item.ops.map((iop) => iop.insert.value).join('')
+        );
       } else {
         liElementsHtml = this._renderInlines(li.item.ops, true);
       }

--- a/test/QuillDeltaToHtmlConverter.test.ts
+++ b/test/QuillDeltaToHtmlConverter.test.ts
@@ -1391,6 +1391,40 @@ describe('QuillDeltaToHtmlConverter', function () {
         ].join('')
       );
     });
+
+    it('should escape html code while rendering code blocks in list', () => {
+      const ops = [
+        { insert: 'hello this is a list.', attributes: {} },
+        { insert: '\n', attributes: { list: { list: 'bullet' } } },
+        { insert: 'code block 1', attributes: {} },
+        {
+          attributes: {
+            'code-block': { 'code-block': 'javascript', 'in-list': 'bullet' },
+          },
+          insert: '\n',
+        },
+        { insert: 'code block 2', attributes: {} },
+        {
+          attributes: {
+            'code-block': { 'code-block': 'javascript', 'in-list': 'bullet' },
+          },
+          insert: '\n',
+        },
+      ];
+
+      const qdc = new QuillDeltaToHtmlConverter(ops, {
+        blocksCanBeWrappedWithList: ['code-block'],
+      });
+      assert.equal(
+        qdc.convert(),
+        [
+          `<ul>` +
+            `<li><p>hello this is a list.</p></li>` +
+            `<li data-none-type=\"true\"><pre data-language=\"javascript\">code block 1\ncode block 2</pre></li>` +
+            `</ul>`,
+        ].join('')
+      );
+    });
   });
 
   describe('custom types', () => {


### PR DESCRIPTION
BugFix: Fix rendering for code blocks nested with list.

It should escape html code while rendering the content in the code blocks wrapped with list.

Before fix:
```
<ul><li><pre>code block 1<br>code block 2</pre></li></ul>
```

Aftre fix:
```
<ul><li><pre>code block 1\ncode block 2</pre></li></ul>
```