### PR TITLE
BugFix:Render table cell with aligned text.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@time-loop/quill-delta-to-html",
-  "version": "0.12.0-58",
+  "version": "0.12.0-59",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@time-loop/quill-delta-to-html",
-      "version": "0.12.0-58",
+      "version": "0.12.0-59",
       "license": "ISC",
       "dependencies": {
         "lodash": "^4.17.21"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@time-loop/quill-delta-to-html",
-  "version": "0.12.0-58",
+  "version": "0.12.0-59",
   "description": "Converts Quill's delta ops to HTML",
   "main": "./dist/commonjs/main.js",
   "types": "./dist/esm/main.d.ts",

--- a/src/OpAttributeSanitizer.ts
+++ b/src/OpAttributeSanitizer.ts
@@ -337,4 +337,9 @@ class OpAttributeSanitizer {
   }
 }
 
-export { OpAttributeSanitizer, IOpAttributes, IOpAttributeSanitizerOptions };
+export {
+  OpAttributeSanitizer,
+  IOpAttributes,
+  IOpAttributeSanitizerOptions,
+  TableCellLineAttributes,
+};

--- a/src/OpToHtmlConverter.ts
+++ b/src/OpToHtmlConverter.ts
@@ -9,7 +9,10 @@ import { ScriptType, NewLine, ListType } from './value-types';
 import * as obj from './helpers/object';
 import { IMention } from './mentions/MentionSanitizer';
 import * as arr from './helpers/array';
-import { OpAttributeSanitizer } from './OpAttributeSanitizer';
+import {
+  OpAttributeSanitizer,
+  TableCellLineAttributes,
+} from './OpAttributeSanitizer';
 
 export type InlineStyleType =
   | ((value: string, op: DeltaInsertOp) => string | undefined)
@@ -218,6 +221,7 @@ class OpToHtmlConverter {
         .concat(this.op.isVideo() ? 'video' : [])
         .concat(this.op.isImage() ? 'image' : [])
         .map(<Str2StrType>this.prefixClass.bind(this))
+        .concat(this.op.isTableCellLine() ? 'qlbt-cell-line' : [])
     );
   }
 
@@ -346,6 +350,17 @@ class OpToHtmlConverter {
       );
     }
 
+    if (this.op.isTableCellLine()) {
+      const opAttrs = this.op.attributes[
+        'table-cell-line'
+      ] as TableCellLineAttributes;
+      const attrKeys = ['row', 'cell', 'rowspan', 'colspan'];
+      const cellLineAttrs = attrKeys.map((key) =>
+        makeAttr(`data-${key}`, opAttrs[key])
+      );
+      tagAttrs = tagAttrs.concat(cellLineAttrs);
+    }
+
     if (this.op.isContainerBlock()) {
       return tagAttrs;
     }
@@ -447,6 +462,7 @@ class OpToHtmlConverter {
       ['indent', positionTag],
       ['layout', positionTag],
       ['advanced-banner', positionTag],
+      ['table-cell-line', positionTag],
     ];
     for (var item of blocks) {
       var firstItem = item[0]!;

--- a/src/QuillDeltaToHtmlConverter.ts
+++ b/src/QuillDeltaToHtmlConverter.ts
@@ -390,20 +390,7 @@ class QuillDeltaToHtmlConverter {
     var converter = new OpToHtmlConverter(line.item.op, this.converterOptions);
     var parts = converter.getHtmlParts();
     var cellElementsHtml = this._renderInlines(line.item.ops, false);
-
-    return (
-      makeStartTag('p', [
-        { key: 'class', value: 'qlbt-cell-line' },
-        { key: 'data-row', value: line.attrs!.row },
-        { key: 'data-cell', value: line.attrs!.cell },
-        { key: 'data-rowspan', value: line.attrs!.rowspan },
-        { key: 'data-colspan', value: line.attrs!.colspan },
-      ]) +
-      parts.openingTag +
-      cellElementsHtml +
-      parts.closingTag +
-      makeEndTag('p')
-    );
+    return parts.openingTag + cellElementsHtml + parts.closingTag;
   }
 
   _renderLayoutRow(row: LayoutRow): string {

--- a/test/QuillDeltaToHtmlConverter.test.ts
+++ b/test/QuillDeltaToHtmlConverter.test.ts
@@ -1143,6 +1143,62 @@ describe('QuillDeltaToHtmlConverter', function () {
       );
     });
 
+    it('should render table with align text', () => {
+      const ops = [
+        {
+          attributes: {
+            'table-col': { width: '150' },
+          },
+          insert: '\n\n',
+        },
+        { insert: 'align text' },
+        {
+          attributes: {
+            'table-cell-line': {
+              rowspan: '1',
+              colspan: '1',
+              row: 'row-dvagmt',
+              cell: 'cell-383p7o',
+            },
+            align: 'center',
+          },
+          insert: '\n',
+        },
+        {
+          attributes: {
+            'table-cell-line': {
+              rowspan: '1',
+              colspan: '1',
+              row: 'row-dvagmt',
+              cell: 'cell-495b7o',
+            },
+          },
+          insert: '\n',
+        },
+      ];
+      const qdc = new QuillDeltaToHtmlConverter(ops);
+      assert.equal(
+        qdc.convert(),
+        [
+          `<div class="clickup-table-view">`,
+          `<table class="clickup-table" style="width: 300px">`,
+          `<colgroup>`,
+          `<col width="150"><col width="150">`,
+          `</colgroup>`,
+          `<tbody>`,
+          `<tr data-row="row-dvagmt">`,
+          `<td data-row="row-dvagmt" rowspan="1" colspan="1">`,
+          `<p class="ql-align-center qlbt-cell-line" data-row="row-dvagmt" data-cell="cell-383p7o" data-rowspan="1" data-colspan="1">align text</p>`,
+          `</td>`,
+          `<td data-row="row-dvagmt" rowspan="1" colspan="1"><p class="qlbt-cell-line" data-row="row-dvagmt" data-cell="cell-495b7o" data-rowspan="1" data-colspan="1"><br/></p></td>`,
+          '</tr>',
+          `</tbody>`,
+          `</table>`,
+          `</div>`,
+        ].join('')
+      );
+    });
+
     // test cases for columns
     it('should render columns with row width', () => {
       let ops = [

--- a/test/QuillDeltaToHtmlConverter.test.ts
+++ b/test/QuillDeltaToHtmlConverter.test.ts
@@ -1166,11 +1166,12 @@ describe('QuillDeltaToHtmlConverter', function () {
         },
         {
           attributes: {
-            'table-cell-line': {
+            list: {
               rowspan: '1',
               colspan: '1',
               row: 'row-dvagmt',
               cell: 'cell-495b7o',
+              list: 'ordered',
             },
           },
           insert: '\n',
@@ -1190,7 +1191,9 @@ describe('QuillDeltaToHtmlConverter', function () {
           `<td data-row="row-dvagmt" rowspan="1" colspan="1">`,
           `<p class="ql-align-center qlbt-cell-line" data-row="row-dvagmt" data-cell="cell-383p7o" data-rowspan="1" data-colspan="1">align text</p>`,
           `</td>`,
-          `<td data-row="row-dvagmt" rowspan="1" colspan="1"><p class="qlbt-cell-line" data-row="row-dvagmt" data-cell="cell-495b7o" data-rowspan="1" data-colspan="1"><br/></p></td>`,
+          `<td data-row="row-dvagmt" rowspan="1" colspan="1">`,
+          `<ol data-row="row-dvagmt" data-cell="cell-495b7o" data-rowspan="1" data-colspan="1"><li><p><br/></p></li></ol>`,
+          `</td>`,
           '</tr>',
           `</tbody>`,
           `</table>`,


### PR DESCRIPTION
BugFix: Comments | Tables that have justified content break if copied from the view state of a comment.
Link to: [Comments | Tables that have justified content break if copied from the view state of a comment.](https://staging.clickup.com/t/333/CLK-326994)

Incorrect rendering table cell line into 3 `p` tags:
<img width="693" alt="image" src="https://github.com/time-loop/quill-delta-to-html/assets/68313886/5a70ccba-685a-430d-8d1f-5a1f44f49249">

Test plan:
Covered by unit test.