### PR TITLE
feat: merge consecutive lines into one

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@time-loop/quill-delta-to-html",
-  "version": "0.12.0-65",
+  "version": "0.12.0-66",
   "description": "Converts Quill's delta ops to HTML",
   "main": "./dist/commonjs/main.js",
   "types": "./dist/esm/main.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@time-loop/quill-delta-to-html",
-  "version": "0.12.0-66",
+  "version": "0.12.0-67",
   "description": "Converts Quill's delta ops to HTML",
   "main": "./dist/commonjs/main.js",
   "types": "./dist/esm/main.d.ts",

--- a/src/QuillDeltaToHtmlConverter.ts
+++ b/src/QuillDeltaToHtmlConverter.ts
@@ -50,6 +50,11 @@ interface IQuillDeltaToHtmlConverterOptions
   multiLineParagraph?: boolean;
   multiLineCustomBlock?: boolean;
   blocksCanBeWrappedWithList?: string[] | undefined;
+  /**
+   * Merge consecutive empty lines into one.
+   * Default is false.
+   */
+  mergeEmptyLines?: boolean;
   customBlockIsEqual?: (g: BlockGroup, gOther: BlockGroup) => boolean;
   customListGroupAttrs?: (g: ListGroup, isRoot: boolean) => ITagKeyValue[];
   customTableCellAttrs?: (g: TableCell) => ITagKeyValue[];
@@ -77,6 +82,7 @@ class QuillDeltaToHtmlConverter {
         multiLineCodeblock: true,
         multiLineParagraph: true,
         multiLineCustomBlock: true,
+        mergeEmptyLines: false,
         allowBackgroundClasses: false,
         linkTarget: '_blank',
       },

--- a/src/QuillDeltaToHtmlConverter.ts
+++ b/src/QuillDeltaToHtmlConverter.ts
@@ -594,7 +594,23 @@ class QuillDeltaToHtmlConverter {
       );
     }
 
-    var inlines = ops.map((op) => this._renderInline(op, bop)).join('');
+    let inlines = '';
+    for (let i = 0; i < ops.length; i++) {
+      const op = ops[i];
+
+      // we want to merge consecutive empty lines into one
+      if (
+        this.options.mergeEmptyLines &&
+        i > 1 &&
+        op.isJustNewline() &&
+        ops[i - 1].isJustNewline() &&
+        ops[i - 2].isJustNewline()
+      ) {
+        continue;
+      }
+
+      inlines += this._renderInline(op, bop);
+    }
     return htmlParts.openingTag + (inlines || BrTag) + htmlParts.closingTag;
   }
 

--- a/src/QuillDeltaToHtmlConverter.ts
+++ b/src/QuillDeltaToHtmlConverter.ts
@@ -55,6 +55,11 @@ interface IQuillDeltaToHtmlConverterOptions
    * Default is false.
    */
   mergeEmptyLines?: boolean;
+  /**
+   * If this is set, the converter
+   * will add a class attribute to the contaienr of the line breaks.
+   */
+  linebreakBlockClassName?: string;
   customBlockIsEqual?: (g: BlockGroup, gOther: BlockGroup) => boolean;
   customListGroupAttrs?: (g: ListGroup, isRoot: boolean) => ITagKeyValue[];
   customTableCellAttrs?: (g: TableCell) => ITagKeyValue[];
@@ -626,6 +631,34 @@ class QuillDeltaToHtmlConverter {
     if (html === BrTag || this.options.multiLineParagraph) {
       return startParaTag + html + endParaTag;
     }
+
+    if (this.options.linebreakBlockClassName) {
+      let result = startParaTag;
+
+      const splits = html.split(BrTag);
+      for (let i = 0; i < splits.length; i++) {
+        const item = splits[i];
+        if (i > 0) {
+          result += makeEndTag(this.options.paragraphTag);
+          if (item === '') {
+            result += makeStartTag(this.options.paragraphTag, [
+              { key: 'class', value: this.options.linebreakBlockClassName },
+            ]);
+          } else {
+            result += makeStartTag(this.options.paragraphTag);
+          }
+        }
+        if (item === '') {
+          result += BrTag;
+        } else {
+          result += item;
+        }
+      }
+
+      result += endParaTag;
+      return result;
+    }
+
     return (
       startParaTag +
       html

--- a/src/QuillDeltaToHtmlConverter.ts
+++ b/src/QuillDeltaToHtmlConverter.ts
@@ -595,14 +595,28 @@ class QuillDeltaToHtmlConverter {
 
   _renderInlines(ops: DeltaInsertOp[], isInlineGroup = true) {
     var opsLen = ops.length - 1;
-    var html = ops
-      .map((op: DeltaInsertOp, i: number) => {
-        if (i > 0 && i === opsLen && op.isJustNewline()) {
-          return '';
-        }
-        return this._renderInline(op, null);
-      })
-      .join('');
+    let html = '';
+
+    for (let i = 0; i < ops.length; i++) {
+      const op = ops[i];
+      if (i > 0 && i === opsLen && op.isJustNewline()) {
+        continue;
+      }
+
+      // we want to merge consecutive empty lines into one
+      if (
+        this.options.mergeEmptyLines &&
+        i > 1 &&
+        op.isJustNewline() &&
+        ops[i - 1].isJustNewline() &&
+        ops[i - 2].isJustNewline()
+      ) {
+        continue;
+      }
+
+      html += this._renderInline(op, null);
+    }
+
     if (!isInlineGroup) {
       return html;
     }

--- a/test/QuillDeltaToHtmlConverter.test.ts
+++ b/test/QuillDeltaToHtmlConverter.test.ts
@@ -2275,7 +2275,7 @@ describe('QuillDeltaToHtmlConverter', function () {
         mergeEmptyLines: true,
       });
       const html = qdc.convert();
-      console.log('html:', html);
+      assert.equal(html, '<p>line1</p><p><br/></p><p>line2</p>');
     });
 
     it('should merge multiple lines', () => {
@@ -2314,7 +2314,7 @@ describe('QuillDeltaToHtmlConverter', function () {
         mergeEmptyLines: true,
       });
       const html = qdc.convert();
-      console.log('html:', html);
+      assert.equal(html, '<p>line1</p><p><br/></p><p>line2</p>');
     });
   });
 });

--- a/test/QuillDeltaToHtmlConverter.test.ts
+++ b/test/QuillDeltaToHtmlConverter.test.ts
@@ -2244,7 +2244,7 @@ describe('QuillDeltaToHtmlConverter', function () {
     });
   });
 
-  describe.only('mergeEmptyLines', () => {
+  describe('mergeEmptyLines', () => {
     it('should behave nomally', () => {
       const ops = [
         { insert: 'line1', attributes: {} },
@@ -2315,6 +2315,49 @@ describe('QuillDeltaToHtmlConverter', function () {
       });
       const html = qdc.convert();
       assert.equal(html, '<p>line1</p><p><br/></p><p>line2</p>');
+    });
+
+    it("should add class to linebreaks' container", () => {
+      const ops = [
+        { insert: 'line1', attributes: {} },
+        {
+          insert: '\n',
+          attributes: {
+            'block-id': 'block-5b7feb38-adb1-4b44-aa69-42d90c6e2e00',
+          },
+        },
+        {
+          insert: '\n',
+          attributes: {
+            'block-id': 'block-5b7feb38-adb1-4b44-aa69-42d90c6e2e00',
+          },
+        },
+        {
+          insert: '\n',
+          attributes: {
+            'block-id': 'block-de1b5382-8c99-41c9-97df-8d927aac907b',
+          },
+        },
+        { insert: 'line2', attributes: {} },
+        {
+          insert: '\n',
+          attributes: {
+            'block-id': 'block-2fa3c7e6-a1ef-45fb-83c7-9833dc0f2606',
+          },
+        },
+      ];
+      const qdc = new QuillDeltaToHtmlConverter(ops, {
+        multiLineParagraph: false,
+        multiLineHeader: false,
+        multiLineCustomBlock: true,
+        mergeEmptyLines: true,
+        linebreakBlockClassName: 'ql-linebreak-container',
+      });
+      const html = qdc.convert();
+      assert.equal(
+        html,
+        '<p>line1</p><p class="ql-linebreak-container"><br/></p><p>line2</p>'
+      );
     });
   });
 });

--- a/test/QuillDeltaToHtmlConverter.test.ts
+++ b/test/QuillDeltaToHtmlConverter.test.ts
@@ -2359,5 +2359,74 @@ describe('QuillDeltaToHtmlConverter', function () {
         '<p>line1</p><p class="ql-linebreak-container"><br/></p><p>line2</p>'
       );
     });
+
+    it('should preserve linebreaks for code block', () => {
+      const ops = [
+        { insert: 'fasdf', attributes: {} },
+        {
+          insert: '\n',
+          attributes: {
+            'block-id': 'block-81f0e1be-3e2e-44a9-8cc6-dc7308563849',
+            'code-block': {
+              'code-block': 'plain',
+              'code-block-line-numbers': 'false',
+            },
+          },
+        },
+        {
+          insert: '\n',
+          attributes: {
+            'block-id': 'block-37b02bf2-c32c-45cb-a084-5ef6d561a740',
+            'code-block': {
+              'code-block': 'plain',
+              'code-block-line-numbers': 'false',
+            },
+          },
+        },
+        {
+          insert: '\n',
+          attributes: {
+            'block-id': 'block-bbebb048-0ca7-4002-b6ea-c436d104f009',
+            'code-block': {
+              'code-block': 'plain',
+              'code-block-line-numbers': 'false',
+            },
+          },
+        },
+        { insert: 'fasdfasdf', attributes: {} },
+        {
+          insert: '\n',
+          attributes: {
+            'block-id': 'block-3549d879-2687-45d4-a1b2-33be06001ce1',
+            'code-block': {
+              'code-block': 'plain',
+              'code-block-line-numbers': 'false',
+            },
+          },
+        },
+        { insert: 'asdf', attributes: {} },
+        {
+          insert: '\n',
+          attributes: {
+            'block-id': 'block-2f2c11bf-9569-46ba-b8b4-8614cf52e4e9',
+          },
+        },
+      ];
+      const qdc = new QuillDeltaToHtmlConverter(ops, {
+        multiLineParagraph: false,
+        multiLineHeader: false,
+        multiLineCustomBlock: true,
+        mergeEmptyLines: true,
+        linebreakBlockClassName: 'ql-linebreak-container',
+      });
+      const html = qdc.convert();
+      assert.equal(
+        html,
+        `<pre data-language="plain">fasdf
+
+
+fasdfasdf</pre><p>asdf</p>`
+      );
+    });
   });
 });

--- a/test/QuillDeltaToHtmlConverter.test.ts
+++ b/test/QuillDeltaToHtmlConverter.test.ts
@@ -2243,4 +2243,78 @@ describe('QuillDeltaToHtmlConverter', function () {
       });
     });
   });
+
+  describe.only('mergeEmptyLines', () => {
+    it('should behave nomally', () => {
+      const ops = [
+        { insert: 'line1', attributes: {} },
+        {
+          insert: '\n',
+          attributes: {
+            'block-id': 'block-5b7feb38-adb1-4b44-aa69-42d90c6e2e00',
+          },
+        },
+        {
+          insert: '\n',
+          attributes: {
+            'block-id': 'block-de1b5382-8c99-41c9-97df-8d927aac907b',
+          },
+        },
+        { insert: 'line2', attributes: {} },
+        {
+          insert: '\n',
+          attributes: {
+            'block-id': 'block-2fa3c7e6-a1ef-45fb-83c7-9833dc0f2606',
+          },
+        },
+      ];
+      const qdc = new QuillDeltaToHtmlConverter(ops, {
+        multiLineParagraph: false,
+        multiLineHeader: false,
+        multiLineCustomBlock: true,
+        mergeEmptyLines: true,
+      });
+      const html = qdc.convert();
+      console.log('html:', html);
+    });
+
+    it('should merge multiple lines', () => {
+      const ops = [
+        { insert: 'line1', attributes: {} },
+        {
+          insert: '\n',
+          attributes: {
+            'block-id': 'block-5b7feb38-adb1-4b44-aa69-42d90c6e2e00',
+          },
+        },
+        {
+          insert: '\n',
+          attributes: {
+            'block-id': 'block-5b7feb38-adb1-4b44-aa69-42d90c6e2e00',
+          },
+        },
+        {
+          insert: '\n',
+          attributes: {
+            'block-id': 'block-de1b5382-8c99-41c9-97df-8d927aac907b',
+          },
+        },
+        { insert: 'line2', attributes: {} },
+        {
+          insert: '\n',
+          attributes: {
+            'block-id': 'block-2fa3c7e6-a1ef-45fb-83c7-9833dc0f2606',
+          },
+        },
+      ];
+      const qdc = new QuillDeltaToHtmlConverter(ops, {
+        multiLineParagraph: false,
+        multiLineHeader: false,
+        multiLineCustomBlock: true,
+        mergeEmptyLines: true,
+      });
+      const html = qdc.convert();
+      console.log('html:', html);
+    });
+  });
 });

--- a/test/QuillDeltaToHtmlConverter.test.ts
+++ b/test/QuillDeltaToHtmlConverter.test.ts
@@ -2428,5 +2428,66 @@ describe('QuillDeltaToHtmlConverter', function () {
 fasdfasdf</pre><p>asdf</p>`
       );
     });
+
+    it('should merge lines in quote', () => {
+      const ops = [
+        { insert: 'asdf', attributes: {} },
+        {
+          insert: '\n',
+          attributes: {
+            'block-id': 'block-dfe32e0c-d47d-4607-89f5-d0a2b0033dcd',
+            blockquote: {},
+          },
+        },
+        {
+          insert: '\n',
+          attributes: {
+            'block-id': 'block-8b218d86-9274-48a0-b9dd-06a6c1c5a6c9',
+            blockquote: {},
+          },
+        },
+        {
+          insert: '\n',
+          attributes: {
+            'block-id': 'block-f783f36b-c994-4976-89b3-7d6150440226',
+            blockquote: {},
+          },
+        },
+        {
+          insert: '\n',
+          attributes: {
+            'block-id': 'block-ab20c98d-1b0d-49f5-ad61-a743c7549e49',
+            blockquote: {},
+          },
+        },
+        { insert: 'fasdf', attributes: {} },
+        {
+          insert: '\n',
+          attributes: {
+            'block-id': 'block-24c2de52-c0d2-4f60-af3e-a85b9e2cf8a6',
+            blockquote: {},
+          },
+        },
+        { insert: 'fasdf', attributes: {} },
+        {
+          insert: '\n',
+          attributes: {
+            'block-id': 'block-124583ce-c283-4af9-a496-40325a09fa6e',
+          },
+        },
+      ];
+      const qdc = new QuillDeltaToHtmlConverter(ops, {
+        multiLineParagraph: false,
+        multiLineHeader: false,
+        multiLineCustomBlock: true,
+        mergeEmptyLines: true,
+        linebreakBlockClassName: 'ql-linebreak-container',
+      });
+      const html = qdc.convert();
+      assert.equal(
+        html,
+        '<blockquote>asdf<br/><br/>fasdf</blockquote><p>fasdf</p>'
+      );
+    });
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
    "compilerOptions": {
       "module": "es6",
-      "removeComments": true,
+      "removeComments": false,
       "preserveConstEnums": true,
       "sourceMap": false,
       "target": "es6",


### PR DESCRIPTION
Add `mergeEmptyLines` options to trigger this feature.
If opened, the converter will merge multiple lines into one line.