### PR TITLE
bugfix(docs): error in _renderTable.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@time-loop/quill-delta-to-html",
-  "version": "0.12.0-69",
+  "version": "0.12.0-70",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@time-loop/quill-delta-to-html",
-      "version": "0.12.0-69",
+      "version": "0.12.0-70",
       "license": "ISC",
       "dependencies": {
         "lodash": "^4.17.21"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@time-loop/quill-delta-to-html",
-  "version": "0.12.0-65",
+  "version": "0.12.0-69",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@time-loop/quill-delta-to-html",
-      "version": "0.12.0-65",
+      "version": "0.12.0-69",
       "license": "ISC",
       "dependencies": {
         "lodash": "^4.17.21"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@time-loop/quill-delta-to-html",
-  "version": "0.12.0-69",
+  "version": "0.12.0-70",
   "description": "Converts Quill's delta ops to HTML",
   "main": "./dist/commonjs/main.js",
   "types": "./dist/esm/main.d.ts",

--- a/src/QuillDeltaToHtmlConverter.ts
+++ b/src/QuillDeltaToHtmlConverter.ts
@@ -18,7 +18,6 @@ import {
   TableRow,
   TableCell,
   TableCol,
-  TableColGroup,
   TableCellLine,
   LayoutRow,
   LayoutColumn,
@@ -311,8 +310,9 @@ class QuillDeltaToHtmlConverter {
   }
 
   _renderTable(table: TableGroup): string {
-    const tableColGroup: TableColGroup = table.colGroup;
+    const tableColGroup = table.colGroup;
     let tableWidth: number = 0;
+    let colgroupStr = '';
     if (tableColGroup && tableColGroup.cols) {
       tableWidth = tableColGroup.cols.reduce(
         (result: number, col: TableCol) => {
@@ -326,6 +326,13 @@ class QuillDeltaToHtmlConverter {
         },
         0
       );
+
+      colgroupStr =
+        makeStartTag('colgroup') +
+        tableColGroup.cols
+          .map((col: TableCol) => this._renderTableCol(col))
+          .join('') +
+        makeEndTag('colgroup');
     }
 
     return (
@@ -334,11 +341,7 @@ class QuillDeltaToHtmlConverter {
         { key: 'class', value: 'clickup-table' },
         { key: 'style', value: !!tableWidth ? `width: ${tableWidth}px` : '' },
       ]) +
-      makeStartTag('colgroup') +
-      tableColGroup.cols
-        .map((col: TableCol) => this._renderTableCol(col))
-        .join('') +
-      makeEndTag('colgroup') +
+      colgroupStr +
       makeStartTag('tbody') +
       table.rows.map((row: TableRow) => this._renderTableRow(row)).join('') +
       makeEndTag('tbody') +

--- a/src/grouper/group-types.ts
+++ b/src/grouper/group-types.ts
@@ -183,8 +183,8 @@ class ListItem {
 
 class TableGroup {
   rows: TableRow[];
-  colGroup: TableColGroup;
-  constructor(rows: TableRow[], colGroup: TableColGroup) {
+  colGroup: TableColGroup | undefined;
+  constructor(rows: TableRow[], colGroup?: TableColGroup) {
     this.rows = rows;
     this.colGroup = colGroup;
   }


### PR DESCRIPTION
Fix the thrown error in `_renderTable` when there's no cols in TableGroup.

![QQ_1727346932363](https://github.com/user-attachments/assets/9e5a81f7-42c3-4b8b-9169-c00a4b9e354d)

Covered by unit tests.