### PR TITLE
BugFix(docs): 2 consecutive empty lines will be rendered as only one empty line.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@time-loop/quill-delta-to-html",
-  "version": "0.12.0-71",
+  "version": "0.12.0-72",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@time-loop/quill-delta-to-html",
-      "version": "0.12.0-71",
+      "version": "0.12.0-72",
       "license": "ISC",
       "dependencies": {
         "lodash": "^4.17.21"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@time-loop/quill-delta-to-html",
-  "version": "0.12.0-71",
+  "version": "0.12.0-72",
   "description": "Converts Quill's delta ops to HTML",
   "main": "./dist/commonjs/main.js",
   "types": "./dist/esm/main.d.ts",

--- a/src/QuillDeltaToHtmlConverter.ts
+++ b/src/QuillDeltaToHtmlConverter.ts
@@ -628,10 +628,12 @@ class QuillDeltaToHtmlConverter {
   ) {
     var opsLen = ops.length - 1;
     let html = '';
+    let skippedANewLine = false;
 
     for (let i = 0; i < ops.length; i++) {
       const op = ops[i];
       if (i > 0 && i === opsLen && op.isJustNewline()) {
+        skippedANewLine = true;
         continue;
       }
 
@@ -658,7 +660,10 @@ class QuillDeltaToHtmlConverter {
 
     let startParaTag = makeStartTag(this.options.paragraphTag);
     let endParaTag = makeEndTag(this.options.paragraphTag);
-    if (html === BrTag || this.options.multiLineParagraph) {
+    if (
+      (html === BrTag && !skippedANewLine) ||
+      this.options.multiLineParagraph
+    ) {
       return startParaTag + html + endParaTag;
     }
 

--- a/test/QuillDeltaToHtmlConverter.test.ts
+++ b/test/QuillDeltaToHtmlConverter.test.ts
@@ -1666,6 +1666,65 @@ describe('QuillDeltaToHtmlConverter', function () {
         ].join('')
       );
     });
+
+    it('should render continuous empty lines when multiLineParagraph is false', function () {
+      var ops = [
+        {
+          insert: 'doc line 1',
+        },
+        {
+          insert: '\n',
+          attributes: {
+            header: 1,
+          },
+        },
+        {
+          insert: '\n',
+        },
+        {
+          insert: 'doc line 2',
+        },
+        {
+          insert: '\n',
+          attributes: {
+            header: 1,
+          },
+        },
+        {
+          insert: '\n\n',
+        },
+        {
+          insert: 'doc line 3',
+        },
+        {
+          insert: '\n',
+          attributes: {
+            header: 1,
+          },
+        },
+        {
+          insert: '\n\n\n',
+        },
+      ];
+      var qdc = new QuillDeltaToHtmlConverter(ops, {
+        multiLineParagraph: false,
+      });
+      var html = qdc.convert();
+      assert.equal(
+        html,
+        [
+          '<h1>doc line 1</h1>',
+          '<p><br/></p>',
+          '<h1>doc line 2</h1>',
+          '<p><br/></p>',
+          '<p><br/></p>',
+          '<h1>doc line 3</h1>',
+          '<p><br/></p>',
+          '<p><br/></p>',
+          '<p><br/></p>',
+        ].join('')
+      );
+    });
   });
 
   describe('custom types', () => {


### PR DESCRIPTION
See unit test case.

Bump a new version: `0.12.0-72`